### PR TITLE
use reasonable prereqs

### DIFF
--- a/lib/Dist/Zilla/Plugin/Config/Git.pm
+++ b/lib/Dist/Zilla/Plugin/Config/Git.pm
@@ -6,15 +6,10 @@ package Dist::Zilla::Plugin::Config::Git;
 #############################################################################
 # Modules
 
-use sanity;
 use Moose;
-use Type::Utils -all;
-use Types::Standard qw(Str ArrayRef RegexpRef);
+use MooseX::Types::Moose qw(Str ArrayRef RegexpRef);
 
 with 'Dist::Zilla::Role::Plugin';
-
-use namespace::clean;
-no warnings 'uninitialized';
 
 #############################################################################
 # Regular Expressions (for subtypes)
@@ -76,28 +71,34 @@ my $valid_git_repo = qr%
 #############################################################################
 # Subtypes
 
-my $GitRepo = declare 'GitRepo',
+use MooseX::Types -declare => [qw(
+   GitRepo
+   GitBranch
+);
+
+subtype GitRepo,
    as Str,
    where { /^$valid_git_repo$/ }
 ;
 
-my $GitBranch = declare 'GitBranch',
+subtype GitBranch,
    as Str,
    where { /^$valid_ref_name$/ }
 ;
+use namespace::clean;
 
 #############################################################################
 # Attributes
 
 has remote => (
    is       => 'ro',
-   isa      => $GitRepo,
+   isa      => GitRepo,
    default  => 'origin',
 );
 
 has local_branch => (
    is       => 'ro',
-   isa      => $GitBranch,
+   isa      => GitBranch,
    default  => 'master',
 );
 
@@ -117,7 +118,7 @@ has allow_dirty => (
 
 has changelog => (
    is       => 'ro',
-   isa      => 'Str',
+   isa      => Str,
    default  => 'Changes',
 );
 

--- a/lib/Dist/Zilla/Role/GitConfig.pm
+++ b/lib/Dist/Zilla/Role/GitConfig.pm
@@ -6,15 +6,14 @@ package Dist::Zilla::Role::GitConfig;
 #############################################################################
 # Modules
 
-use sanity;
 use Moose::Role;
-use Types::Standard qw(Str RegexpRef);
+use MooseX::Types::Moose qw(Str RegexpRef);
 
-use List::AllUtils qw(first);
+use List::Util qw(first);
+
 use String::Errf qw(errf);  # We are here to save the errf: E-R-R-F!
 
 use namespace::clean;
-no warnings 'uninitialized';
 
 #############################################################################
 # Requirements


### PR DESCRIPTION
This module uses a bunch of extra prereqs for no gain, duplicating the things already used everywhere else in Dist::Zilla.
